### PR TITLE
feat: update stamping navigation and expose machine IDs

### DIFF
--- a/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
+++ b/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
@@ -9,6 +9,7 @@ type SessionRecord = {
   clockOutAt?: string | null;
   hours?: number | null;
   status: '正常' | '稼働中';
+  machineId?: string | null;
 };
 
 type SessionGroup = {
@@ -237,7 +238,10 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
                                 key={`${session.userName}-${session.clockInAt}-${index}`}
                                 className="py-2 first:pt-0 last:pb-0"
                               >
-                                <p className="text-xs text-brand-muted sm:text-sm">{session.siteName ?? '現場未設定'}</p>
+                                <p className="text-xs text-brand-muted sm:text-sm">
+                                  {session.siteName ?? '現場未設定'}
+                                  {session.machineId ? ` ／ 機械ID: ${session.machineId}` : ''}
+                                </p>
                                 <div className="mt-1 flex flex-wrap items-center gap-x-2 text-sm text-brand-text">
                                   <span>
                                     {session.clockInAt}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,24 +1,24 @@
 import Link from 'next/link';
 import type { ReactNode } from 'react';
+import { auth } from '@/lib/auth';
 
-export default function ProtectedLayout({ children }: { children: ReactNode }) {
+export default async function ProtectedLayout({ children }: { children: ReactNode }) {
+  const session = await auth();
+  const displayName = session?.user?.name ?? session?.user?.email ?? '';
+
   return (
     <div className="flex flex-1 flex-col gap-6">
-      <nav
-        aria-label="保護エリア内ナビゲーション"
-        role="navigation"
-        className="flex flex-wrap items-center gap-3 rounded-lg border border-brand-border bg-brand-surface-alt px-4 py-3 text-sm font-medium"
-      >
-        <Link href="/dashboard" className="tap-target text-brand-primary hover:text-brand-primary/80">
-          ダッシュボード
-        </Link>
-        <span aria-hidden="true" className="text-brand-muted">
-          /
-        </span>
-        <Link href="/nfc" className="tap-target text-brand-primary hover:text-brand-primary/80">
-          NFC打刻
-        </Link>
-      </nav>
+      <header className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-brand-border bg-brand-surface-alt px-4 py-3">
+        <nav aria-label="保護エリア内ナビゲーション" role="navigation" className="flex items-center gap-4 text-sm font-medium">
+          <Link href="/dashboard" className="tap-target text-brand-primary hover:text-brand-primary/80">
+            ダッシュボード
+          </Link>
+          <Link href="/nfc" className="tap-target text-brand-primary hover:text-brand-primary/80">
+            打刻ページ
+          </Link>
+        </nav>
+        {displayName ? <span className="text-sm font-medium text-brand-text">{displayName}</span> : null}
+      </header>
       <div className="flex-1">{children}</div>
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
                 ダッシュボード
               </Link>
               <Link href="/nfc" className="tap-target text-brand-primary hover:text-brand-primary/80">
-                NFC打刻
+                打刻ページ
               </Link>
             </nav>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ export default async function Home() {
   const session = await auth();
 
   if (session) {
-    // ユーザーがログインしている場合、NFC打刻ページにリダイレクトします
+    // ユーザーがログインしている場合、打刻ページにリダイレクトします
     redirect('/nfc');
   } else {
     // ユーザーがログインしていない場合、ログインページにリダイレクトします

--- a/lib/airtable/logs.ts
+++ b/lib/airtable/logs.ts
@@ -1,6 +1,6 @@
 import { Record as AirtableRecord } from 'airtable';
-import { logsTable } from '@/lib/airtable';
-import type { LogFields } from '@/types';
+import { logsTable, machinesTable } from '@/lib/airtable';
+import type { LogFields, MachineFields } from '@/types';
 import { getUsersMap } from './users';
 import { AIRTABLE_PAGE_SIZE, JST_OFFSET, LOG_FIELDS } from './schema';
 
@@ -18,6 +18,8 @@ export type NormalizedLog = {
   siteName: string | null;
   workType: string | null;
   note: string | null;
+  machineRecordId: string | null;
+  machineId: string | null;
 };
 
 export type CalendarDaySummary = {
@@ -37,10 +39,12 @@ export type SessionDetail = {
   clockOutAt?: string;
   hours?: number;
   status: SessionStatus;
+  machineId?: string | null;
 };
 
 const RETRY_LIMIT = 3;
 const RETRY_DELAY = 500;
+const MACHINE_BATCH_SIZE = 10;
 
 async function withRetry<T>(factory: () => Promise<T>, attempt = 0): Promise<T> {
   try {
@@ -53,6 +57,40 @@ async function withRetry<T>(factory: () => Promise<T>, attempt = 0): Promise<T> 
     await new Promise((resolve) => setTimeout(resolve, delay));
     return withRetry(factory, attempt + 1);
   }
+}
+
+function escapeFormulaValue(value: string) {
+  return value.replace(/'/g, "''");
+}
+
+async function fetchMachineIdMap(ids: readonly string[]): Promise<Map<string, string>> {
+  const unique = Array.from(new Set(ids.filter((id): id is string => typeof id === 'string' && id.length > 0)));
+  if (unique.length === 0) {
+    return new Map();
+  }
+
+  const map = new Map<string, string>();
+  for (let index = 0; index < unique.length; index += MACHINE_BATCH_SIZE) {
+    const slice = unique.slice(index, index + MACHINE_BATCH_SIZE);
+    const filterByFormula = `OR(${slice.map((id) => `RECORD_ID()='${escapeFormulaValue(id)}'`).join(',')})`;
+    const records = await withRetry(() =>
+      machinesTable
+        .select({
+          filterByFormula,
+          fields: ['machineid'],
+          pageSize: slice.length,
+        })
+        .all(),
+    );
+    for (const record of records) {
+      const fields = record.fields as MachineFields;
+      if (typeof fields.machineid === 'string' && fields.machineid.length > 0) {
+        map.set(record.id, fields.machineid);
+      }
+    }
+  }
+
+  return map;
 }
 
 function toNormalizedLog(record: AirtableRecord<LogFields>): NormalizedLog | null {
@@ -75,6 +113,9 @@ function toNormalizedLog(record: AirtableRecord<LogFields>): NormalizedLog | nul
   const userIdField = typeof fields['userId'] === 'string' ? (fields['userId'] as string) : null;
   const siteLinks = Array.isArray(fields[LOG_FIELDS.site])
     ? (fields[LOG_FIELDS.site] as readonly string[])
+    : [];
+  const machineLinks = Array.isArray(fields['machine'])
+    ? (fields['machine'] as readonly string[])
     : [];
   const userName = typeof fields[LOG_FIELDS.userName] === 'string'
     ? (fields[LOG_FIELDS.userName] as string)
@@ -126,6 +167,13 @@ function toNormalizedLog(record: AirtableRecord<LogFields>): NormalizedLog | nul
     siteName,
     workType,
     note,
+    machineRecordId: machineLinks.length > 0 ? String(machineLinks[0]) : null,
+    machineId:
+      typeof fields['machineId'] === 'string'
+        ? (fields['machineId'] as string)
+        : typeof fields['machineid'] === 'string'
+        ? (fields['machineid'] as string)
+        : null,
   };
 }
 
@@ -145,14 +193,31 @@ export async function getLogsBetween(params: { from: Date; to: Date }): Promise<
       .all(),
   );
 
-  const logs = records
+  const normalized = records
     .map((record) => toNormalizedLog(record))
-    .filter((log): log is NormalizedLog => Boolean(log))
-    .sort((a, b) => a.timestampMs - b.timestampMs);
+    .filter((log): log is NormalizedLog => Boolean(log));
 
-  if (logs.length === 0) {
-    return logs;
+  if (normalized.length === 0) {
+    return normalized;
   }
+
+  const machineLookupIds = normalized
+    .filter((log) => !log.machineId && log.machineRecordId)
+    .map((log) => log.machineRecordId as string);
+  const machineIdMap = machineLookupIds.length > 0 ? await fetchMachineIdMap(machineLookupIds) : new Map();
+
+  const logs = normalized
+    .map((log) => {
+      if (log.machineId || !log.machineRecordId) {
+        return log;
+      }
+      const resolved = machineIdMap.get(log.machineRecordId) ?? null;
+      if (!resolved) {
+        return log;
+      }
+      return { ...log, machineId: resolved } as NormalizedLog;
+    })
+    .sort((a, b) => a.timestampMs - b.timestampMs);
 
   const usersMap = await getUsersMap();
 
@@ -220,6 +285,7 @@ function createOpenSession(source: NormalizedLog): SessionDetail {
     siteName: source.siteName ?? null,
     clockInAt: formatJstTime(source.timestampMs),
     status: '稼働中',
+    machineId: source.machineId ?? null,
   };
 }
 
@@ -259,6 +325,7 @@ function buildSessionDetails(logs: NormalizedLog[]): SessionDetail[] {
       clockOutAt: formatJstTime(log.timestampMs),
       hours: roundHours(durationHours),
       status: '正常',
+      machineId: currentOpen.machineId ?? log.machineId ?? null,
     });
     openSessions.set(userKey, null);
   }

--- a/tests/calendar/api.day.test.mjs
+++ b/tests/calendar/api.day.test.mjs
@@ -130,6 +130,7 @@ test('day API returns paired sessions without punches detail', async () => {
       siteName: '札幌第一',
       workType: '溶接',
       note: null,
+      machineId: '1001',
     },
     {
       id: 'log-2',
@@ -142,6 +143,7 @@ test('day API returns paired sessions without punches detail', async () => {
       siteName: '札幌第一',
       workType: '溶接',
       note: '現地確認',
+      machineId: '1001',
     },
     {
       id: 'log-3',
@@ -166,6 +168,7 @@ test('day API returns paired sessions without punches detail', async () => {
       siteName: '帯広東',
       workType: null,
       note: null,
+      machineId: '2002',
     },
     {
       id: 'log-5',
@@ -178,6 +181,7 @@ test('day API returns paired sessions without punches detail', async () => {
       siteName: '帯広東',
       workType: null,
       note: null,
+      machineId: '2002',
     },
     {
       id: 'log-6',
@@ -190,6 +194,7 @@ test('day API returns paired sessions without punches detail', async () => {
       siteName: '札幌第一',
       workType: '溶接',
       note: null,
+      machineId: '1001',
     },
   ];
   const getLogsMock = mock.fn(async () => baseLogs);
@@ -207,10 +212,12 @@ test('day API returns paired sessions without punches detail', async () => {
   assert.strictEqual(firstSession.clockOutAt, '16:30');
   assert.strictEqual(firstSession.hours, 7.5);
   assert.strictEqual(firstSession.status, '正常');
+  assert.strictEqual(firstSession.machineId, '1001');
   const secondSession = body.sessions[1];
   assert.strictEqual(secondSession.userName, 'sato');
   assert.strictEqual(secondSession.hours, 7);
   assert.strictEqual(secondSession.status, '正常');
+  assert.strictEqual(secondSession.machineId, '2002');
   const hasClosed = body.sessions.some((session) => session.status === '正常');
   assert.ok(hasClosed, 'closed session should exist');
   const hasOpen = body.sessions.some(
@@ -222,4 +229,5 @@ test('day API returns paired sessions without punches detail', async () => {
   assert.strictEqual('clockOutAt' in openSession, false);
   assert.strictEqual('hours' in openSession, false);
   assert.strictEqual(openSession.clockInAt, '21:00');
+  assert.strictEqual(openSession.machineId, '1001');
 });


### PR DESCRIPTION
## 目的 / 影響範囲 / 触るファイル
- 目的: 打刻ページまわりの表示仕様更新と日次セッションへの machineId 付与
- 影響範囲: `/dashboard` ドロワー、共通レイアウト、ログ API ロジック
- 触るファイル: `app/(protected)/layout.tsx`, `app/layout.tsx`, `app/page.tsx`, `app/(protected)/dashboard/_components/DayDetailDrawer.tsx`, `lib/airtable/logs.ts`, `tests/calendar/api.day.test.mjs`

## 変更点
- 保護レイアウトにナビゲーションとユーザー名（濃色テキスト）を再配置
- 「NFC打刻」表記を「打刻ページ」に統一
- 日次 API ログ整形時に Machines テーブルから machineId を解決
- セッション概要で machineId を表示し、該当テストを拡張

## 影響範囲
- ログ API の Airtable アクセスが Machines テーブル参照を追加
- ダッシュボード UI のヘッダー表記と配色

## ロールバック手順
- `git revert <commit>` を実行

## テスト結果
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68e4fb305dac8329bf84ef793605a459