### PR TITLE
feat: show machine info in day detail

### DIFF
--- a/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
+++ b/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
@@ -9,6 +9,7 @@ type SessionRecord = {
   clockOutAt?: string | null;
   hours?: number | null;
   status: '正常' | '稼働中';
+  machineId?: string;
 };
 
 type SessionGroup = {
@@ -215,7 +216,7 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
           ) : detail ? (
             <div className="space-y-4">
               <section>
-                <h4 className="text-sm font-semibold text-brand-text">セッション概要</h4>
+                <h4 className="text-sm font-semibold text-brand-text">稼働状況</h4>
                 {sessionGroups.length === 0 ? (
                   <p className="mt-2 text-sm text-brand-muted">この日にペアリングされたセッションはありません。</p>
                 ) : (
@@ -226,7 +227,9 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
                         className="rounded-2xl border border-brand-border bg-brand-surface-alt p-4 shadow-sm sm:p-5"
                       >
                         <div className="flex items-center justify-between">
-                          <p className="text-[15px] font-semibold text-brand-text sm:text-base">{group.userName}</p>
+                          <p className="text-[15px] font-semibold text-brand-text text-black sm:text-base">
+                            {group.userName}
+                          </p>
                         </div>
                         <div className="mt-2 divide-y divide-brand-border/60">
                           {group.items.map((session, index) => {
@@ -247,6 +250,10 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
                                   </span>
                                   {typeof session.hours === 'number' ? <span>（{session.hours}時間）</span> : null}
                                   <span className={`text-xs sm:text-sm ${statusClass}`}>{session.status}</span>
+                                </div>
+                                <div className="mt-1 text-sm text-brand-text">
+                                  <span className="mr-2 opacity-70">機械</span>
+                                  <span className="tabular-nums">{session.machineId ?? '-'}</span>
                                 </div>
                               </div>
                             );

--- a/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
+++ b/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
@@ -227,7 +227,7 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
                         className="rounded-2xl border border-brand-border bg-brand-surface-alt p-4 shadow-sm sm:p-5"
                       >
                         <div className="flex items-center justify-between">
-                          <p className="text-[15px] font-semibold text-brand-text text-black sm:text-base">
+                          <p className="text-[15px] font-semibold text-brand-text !text-black !opacity-100 sm:text-base">
                             {group.userName}
                           </p>
                         </div>


### PR DESCRIPTION
目的: 日次詳細ドロワに機械IDを表示し、見出しとユーザー名の視認性を改善する。
影響範囲: ダッシュボード日次詳細UI、/api/calendar/day APIレスポンス、該当APIのユニットテスト。
触るファイル: app/(protected)/dashboard/_components/DayDetailDrawer.tsx / app/api/calendar/day/route.ts / tests/calendar/api.day.test.mjs

## 変更点
- /api/calendar/day で IN ログから machineId/machineid を抽出し、セッション配列へ任意プロパティとして付与。
- DayDetailDrawer の見出しを「稼働状況」に変更し、ユーザー名のテキストカラーを強制しつつ機械ラベルを追加表示。
- API テストを拡張し、ログ fields からの machineId 解決を検証。

## 影響範囲
- 日次詳細ドロワを利用する UI。
- /api/calendar/day のレスポンスを利用するクライアント (machineId プロパティは後方互換な任意項目)。

## ロールバック手順
- `git revert 65a62d38695f44986e31bf7955c1cea5e2edca99`
- 再デプロイ。

## テスト結果
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68e5c482efdc83298f898d2fae4169d2