### PR TITLE
fix: resolve machine id for calendar day API

### DIFF
--- a/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
+++ b/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
@@ -253,7 +253,11 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
                                 </div>
                                 <div className="mt-1 text-sm text-brand-text">
                                   <span className="mr-2 opacity-70">機械</span>
-                                  <span className="tabular-nums">{session.machineId ?? '-'}</span>
+                                  <span className="tabular-nums">
+                                    {session.machineId && String(session.machineId).trim().length > 0
+                                      ? session.machineId
+                                      : '-'}
+                                  </span>
                                 </div>
                               </div>
                             );

--- a/app/api/calendar/day/route.ts
+++ b/app/api/calendar/day/route.ts
@@ -3,11 +3,32 @@ import { auth } from '@/lib/auth';
 import { buildDayDetail, getLogsBetween, type NormalizedLog } from '@/lib/airtable/logs';
 
 type MachineLogExtras = {
-  machine?: string | number | null;
-  machineId?: string | number | null;
-  machineid?: string | number | null;
+  machine?: string | number | readonly string[] | null;
+  machineId?: string | number | readonly string[] | null;
+  machineid?: string | number | readonly string[] | null;
   fields?: Record<string, unknown> | null;
 };
+
+type MachinesListResponse = {
+  records?: Array<{
+    id: string;
+    fields?: {
+      machineId?: string | number | null;
+      machineid?: string | number | null;
+    } | null;
+  }>;
+};
+
+const chunk = <T,>(items: readonly T[], size: number) => {
+  const batches: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
+};
+
+const buildFilterFormula = (ids: readonly string[]) =>
+  `OR(${ids.map((id) => `RECORD_ID()='${id}'`).join(',')})`;
 
 function normalizeMachineId(raw: unknown): string | undefined {
   if (raw === undefined || raw === null) {
@@ -17,12 +38,34 @@ function normalizeMachineId(raw: unknown): string | undefined {
   return value.length === 0 ? undefined : value;
 }
 
-function extractMachineId(log: NormalizedLog): string | undefined {
+function extractMachineLinkId(raw: unknown): string | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return undefined;
+  }
+  const first = raw[0];
+  return typeof first === 'string' ? first : undefined;
+}
+
+function resolveMachineValue(
+  raw: unknown,
+  linkMap: ReadonlyMap<string, string>,
+): string | undefined {
+  const linked = extractMachineLinkId(raw);
+  if (linked) {
+    return linkMap.get(linked);
+  }
+  if (Array.isArray(raw)) {
+    return undefined;
+  }
+  return normalizeMachineId(raw);
+}
+
+function extractMachineId(log: NormalizedLog, linkMap: ReadonlyMap<string, string>): string | undefined {
   const extras = log as NormalizedLog & MachineLogExtras;
   const direct =
-    normalizeMachineId(extras.machine) ??
-    normalizeMachineId(extras.machineId) ??
-    normalizeMachineId(extras.machineid);
+    resolveMachineValue(extras.machine, linkMap) ??
+    resolveMachineValue(extras.machineId, linkMap) ??
+    resolveMachineValue(extras.machineid, linkMap);
   if (direct) {
     return direct;
   }
@@ -32,13 +75,16 @@ function extractMachineId(log: NormalizedLog): string | undefined {
   }
   const record = fields as Record<string, unknown>;
   return (
-    normalizeMachineId(record.machine) ??
-    normalizeMachineId(record.machineId) ??
-    normalizeMachineId(record.machineid)
+    resolveMachineValue(record.machine, linkMap) ??
+    resolveMachineValue(record.machineId, linkMap) ??
+    resolveMachineValue(record.machineid, linkMap)
   );
 }
 
-function collectMachineAssignments(logs: NormalizedLog[]): (string | undefined)[] {
+function collectMachineAssignments(
+  logs: NormalizedLog[],
+  linkMap: ReadonlyMap<string, string>,
+): (string | undefined)[] {
   type OpenSessionState = { log: NormalizedLog; machineId?: string } | null;
   const sorted = [...logs].sort((a, b) => a.timestampMs - b.timestampMs);
   const openSessions = new Map<string, OpenSessionState>();
@@ -52,7 +98,7 @@ function collectMachineAssignments(logs: NormalizedLog[]): (string | undefined)[
       if (currentOpen) {
         machineQueue.push(currentOpen.machineId);
       }
-      openSessions.set(userKey, { log, machineId: extractMachineId(log) });
+      openSessions.set(userKey, { log, machineId: extractMachineId(log, linkMap) });
       continue;
     }
 
@@ -81,6 +127,76 @@ export const runtime = 'nodejs';
 
 function errorResponse(code: string, status: number) {
   return NextResponse.json({ error: code }, { status });
+}
+
+async function resolveMachineLinkMap(ids: readonly string[]): Promise<Map<string, string>> {
+  const apiKey = process.env.AIRTABLE_API_KEY;
+  const baseId = process.env.AIRTABLE_BASE_ID;
+  if (!apiKey || !baseId || ids.length === 0) {
+    return new Map();
+  }
+
+  const resolved = new Map<string, string>();
+  for (const batch of chunk(ids, 15)) {
+    if (batch.length === 0) {
+      continue;
+    }
+    const params = new URLSearchParams();
+    params.set('filterByFormula', buildFilterFormula(batch));
+    params.append('fields[]', 'machineId');
+    params.append('fields[]', 'machineid');
+    const url = `https://api.airtable.com/v0/${baseId}/Machines?${params.toString()}`;
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-store',
+      });
+      if (!response.ok) {
+        console.error('[calendar][day] failed to list machines', response.status, await response.text());
+        continue;
+      }
+      const payload = (await response.json()) as MachinesListResponse;
+      for (const record of payload.records ?? []) {
+        const value = normalizeMachineId(record.fields?.machineId ?? record.fields?.machineid);
+        if (value) {
+          resolved.set(record.id, value);
+        }
+      }
+    } catch (error) {
+      console.error('[calendar][day] machine lookup failed', error);
+    }
+  }
+  return resolved;
+}
+
+function collectMachineLinkIds(logs: NormalizedLog[]): string[] {
+  const identifiers = new Set<string>();
+  for (const log of logs) {
+    if (log.type !== 'IN') {
+      continue;
+    }
+    const extras = log as NormalizedLog & MachineLogExtras;
+    const { fields } = extras;
+    const candidates = [extras.machine, extras.machineId, extras.machineid];
+    if (fields && typeof fields === 'object') {
+      const record = fields as Record<string, unknown>;
+      const fromMachine = record.machine as MachineLogExtras['machine'];
+      const fromMachineId = record.machineId as MachineLogExtras['machineId'];
+      const fromMachineid = record.machineid as MachineLogExtras['machineid'];
+      candidates.push(fromMachine, fromMachineId, fromMachineid);
+    }
+    for (const candidate of candidates) {
+      const linkId = extractMachineLinkId(candidate);
+      if (linkId) {
+        identifiers.add(linkId);
+      }
+    }
+  }
+  return Array.from(identifiers);
 }
 
 function resolveDayRange(date: string) {
@@ -118,7 +234,9 @@ export async function GET(req: NextRequest) {
     }
 
     const logs = await getLogsBetween(range);
-    const machineAssignments = collectMachineAssignments(logs);
+    const machineLinkIds = collectMachineLinkIds(logs);
+    const machineLinkMap = await resolveMachineLinkMap(machineLinkIds);
+    const machineAssignments = collectMachineAssignments(logs, machineLinkMap);
     const { sessions } = buildDayDetail(logs);
     const sessionsWithMachine = sessions.map((session, index) => ({
       ...session,

--- a/types/index.ts
+++ b/types/index.ts
@@ -64,3 +64,18 @@ export type StampRecord = {
   accuracy?: number;
   createdAt: string;
 };
+
+export type DaySession = {
+  userId: string;
+  username: string;
+  sitename: string;
+  workdescription?: string | null;
+  clockInAt?: string | null;
+  clockOutAt?: string | null;
+  hours?: number | null;
+  /**
+   * Machines.machineId を API 側で解決して付与。
+   * UI で「機械」欄にそのまま表示する。
+   */
+  machineId?: string | null;
+};


### PR DESCRIPTION
目的: /api/calendar/day のセッションに machineId を復元して UI の機械表示を正しくする
影響範囲: カレンダー日別 API のセッションレスポンス (machineId 付与)
触るファイル: app/api/calendar/day/route.ts

再現手順
- /api/calendar/day を machine フィールドが Machines 参照のログで呼び出すと machineId が null/undefined のまま

修正内容
- IN ログから Machines 参照 ID を収集し、小分けで Airtable Machines テーブルをフェッチ
- recID→machineId のマップを構築し、リンク値/直接値/フォールバック値から machineId を解決して各セッションに付与

確認手順
- pnpm build
- pnpm test
- pnpm lint
- UAT 日報で機械欄に 1200 などの machineId が表示されることを確認しスクリーンショット取得

------
https://chatgpt.com/codex/tasks/task_e_68e5cccd1fe08329a6b253a4830042b9