### PR TITLE
chore: adjust dashboard stamp navigation

### DIFF
--- a/app/(protected)/dashboard/_components/NfcLinkButton.tsx
+++ b/app/(protected)/dashboard/_components/NfcLinkButton.tsx
@@ -11,7 +11,7 @@ export default function NfcLinkButton() {
     <Link
       href={`/nfc?${qs}`}
       prefetch
-      aria-label="打刻ページ"
+      aria-label="打刻ページ（会社）"
       className="tap-target inline-flex items-center gap-2 rounded-xl border border-brand-border bg-brand-primary px-4 py-2 text-sm font-semibold text-brand-primaryText shadow-sm transition hover:bg-brand-primary/90"
     >
       <svg
@@ -27,7 +27,7 @@ export default function NfcLinkButton() {
         <path d="M5 8a7 7 0 0 1 14 0v8a7 7 0 0 1-14 0Z" />
         <path d="M12 6v12" />
       </svg>
-      打刻ページへ
+      打刻ページ（会社）
     </Link>
   );
 }

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -13,9 +13,6 @@ export default async function ProtectedLayout({ children }: { children: ReactNod
           <Link href="/dashboard" className="tap-target text-brand-primary hover:text-brand-primary/80">
             ダッシュボード
           </Link>
-          <Link href="/nfc" className="tap-target text-brand-primary hover:text-brand-primary/80">
-            打刻ページ
-          </Link>
         </nav>
         {displayName ? <span className="text-sm font-medium text-brand-text">{displayName}</span> : null}
       </header>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,9 +25,6 @@ export default function RootLayout({
               <Link href="/dashboard" className="tap-target text-brand-primary hover:text-brand-primary/80">
                 ダッシュボード
               </Link>
-              <Link href="/nfc" className="tap-target text-brand-primary hover:text-brand-primary/80">
-                打刻ページ
-              </Link>
             </nav>
           </div>
         </header>


### PR DESCRIPTION
目的: ダッシュボード上部の打刻ページ導線を仕様に合わせる
影響範囲: ルート/保護レイアウトのナビゲーション、ダッシュボード打刻ボタン
触るファイル: app/layout.tsx, app/(protected)/layout.tsx, app/(protected)/dashboard/_components/NfcLinkButton.tsx

不要な打刻ページボタン削除／ラベル変更のみ。リンク先は不変。

## 変更点
- ルート/保護レイアウトから青背景でない打刻ページリンクを削除
- 打刻ページボタンのラベルとaria-labelを「打刻ページ（会社）」に変更

## 影響範囲
- ダッシュボードおよび共有ヘッダーのナビゲーション表示

## ロールバック手順
- このPRの変更をRevertする

## テスト結果
- pnpm build
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e5d1cebf80832990ba8af33af310cd